### PR TITLE
Fix rustdoc warnings surfaced by the strict docs CI job

### DIFF
--- a/crates/synaptic-eval/src/calibrate.rs
+++ b/crates/synaptic-eval/src/calibrate.rs
@@ -8,7 +8,7 @@
 //! predicted co-change, so this turns "is the predictor's confidence meaningful"
 //! into a measured number rather than a claim.
 
-/// One (predicted probability in [0,1], observed boolean outcome) sample.
+/// One (predicted probability in \[0,1\], observed boolean outcome) sample.
 #[derive(Debug, Clone, Copy)]
 pub struct Sample {
     pub confidence: f64,
@@ -60,7 +60,7 @@ pub fn brier(samples: &[Sample]) -> f64 {
     sum / samples.len() as f64
 }
 
-/// Bin samples into `n_bins` equal-width buckets over [0,1] and compute, per
+/// Bin samples into `n_bins` equal-width buckets over \[0,1\] and compute, per
 /// bucket, the mean confidence and the observed hit rate.
 pub fn reliability(samples: &[Sample], n_bins: usize) -> CalibrationReport {
     let n_bins = n_bins.max(1);

--- a/crates/synaptic-extract/src/cache.rs
+++ b/crates/synaptic-extract/src/cache.rs
@@ -2,7 +2,7 @@
 //! file on a rebuild skips tree-sitter parsing. The cached value is the
 //! serialized [`ExtractionResult`] under `<cache_dir>/ast/v{version}/<key>.<ext>`,
 //! where `<ext>` is `mp` (MessagePack, the default `cache-binary` feature) or
-//! `json` when that feature is off -- see [`CACHE_EXT`].
+//! `json` when that feature is off -- see `CACHE_EXT`.
 //! The path is part of the key because node ids and scoping
 //! embed it, so two files with identical bytes at different paths must not share
 //! an entry. Entries are namespaced by [`AST_CACHE_VERSION`] so a release *or* an

--- a/crates/synaptic-extract/src/dotnet.rs
+++ b/crates/synaptic-extract/src/dotnet.rs
@@ -12,7 +12,7 @@
 //! Project-reference targets use the **root-relative resolved path** as their id
 //! (`file_node_id`), so a reference lands on the referenced project's own file
 //! node when it is in the corpus. Synaptic keys file nodes by their portable
-//! relative ids (see [`crate::paths::resolve_relative_path`]).
+//! relative ids (see `crate::paths::resolve_relative_path`).
 
 #[cfg(feature = "lang-dotnet")]
 use std::collections::{HashMap, HashSet};

--- a/crates/synaptic-graph/src/betweenness.rs
+++ b/crates/synaptic-graph/src/betweenness.rs
@@ -3,7 +3,7 @@
 //! questions and the no-community surprise fallback. Equivalent to the standard
 //! normalized betweenness / edge-betweenness centrality measures.
 //!
-//! For graphs over [`SAMPLE_THRESHOLD`] nodes, node betweenness is
+//! For graphs over `SAMPLE_THRESHOLD` nodes, node betweenness is
 //! approximated from the first `min(SAMPLE_K, n)` source nodes (sorted-id order)
 //! and rescaled by `n/k` — deterministic `k`-sampling without RNG
 //! (the analysis layer forbids RNG for reproducibility).

--- a/crates/synaptic-graph/src/cluster.rs
+++ b/crates/synaptic-graph/src/cluster.rs
@@ -1,6 +1,6 @@
 //! Community clustering: the public `cluster()` entry point plus `cohesion_score`,
 //! `remap_communities_to_previous`, and `apply_communities`. Wraps the in-house
-//! Louvain/Leiden algorithms in [`crate::community`] with
+//! Louvain/Leiden algorithms in `crate::community` with
 //! post-processing (hub exclusion, splitting, deterministic renumber).
 
 use std::cmp::Reverse;

--- a/crates/synaptic-incremental/src/concurrency.rs
+++ b/crates/synaptic-incremental/src/concurrency.rs
@@ -33,7 +33,7 @@ impl Drop for RebuildLock {
 
 /// Try to acquire the per-repo rebuild lock under `out_dir`, non-blocking.
 /// Returns `Ok(None)` if another (live) process holds it. A stale lockfile
-/// (older than [`STALE_AFTER`]) is stolen.
+/// (older than `STALE_AFTER`) is stolen.
 pub fn try_acquire_lock(out_dir: &Path) -> std::io::Result<Option<RebuildLock>> {
     fs::create_dir_all(out_dir)?;
     let path = out_dir.join(LOCK_FILE);

--- a/crates/synaptic-ingest/src/url.rs
+++ b/crates/synaptic-ingest/src/url.rs
@@ -1,5 +1,5 @@
 //! URL ingestion. Fetches a URL through the SSRF-guarded
-//! [`safe_fetch`](crate::security::safe_fetch) and writes a file into the target
+//! [`safe_fetch`] and writes a file into the target
 //! dir for the normal extraction pass to pick up ("shape A").
 //!
 //! Webpage/arXiv/tweet/GitHub → HTML scraped to markdown with YAML frontmatter;

--- a/crates/synaptic-llm/src/vision.rs
+++ b/crates/synaptic-llm/src/vision.rs
@@ -157,7 +157,7 @@ pub fn strip_pixels(refs: &[ImageRef]) -> Vec<ImageRef> {
 }
 
 /// Whether `backend`'s configured model can see images. Ollama is the opt-in
-/// special case ([`OLLAMA_VISION_ENV`]=`1`); everything else uses the registry
+/// special case (`OLLAMA_VISION_ENV`=`1`); everything else uses the registry
 /// `vision` flag.
 pub fn backend_supports_vision(backend: &str, get: &impl Fn(&str) -> Option<String>) -> bool {
     if backend == "ollama" {

--- a/crates/synaptic-predict/src/risk.rs
+++ b/crates/synaptic-predict/src/risk.rs
@@ -46,7 +46,7 @@ struct Feature {
 }
 
 /// Score a change from its risk factors. Each feature saturates at a cap, is
-/// weighted, and the weighted sum (in [0,1]) becomes a 0..100 score with low /
+/// weighted, and the weighted sum (in \[0,1\]) becomes a 0..100 score with low /
 /// medium / high bands. `factors` lists the features that contributed most.
 pub fn assess_risk(f: &RiskFactors) -> RiskScore {
     // Caps are where a feature stops adding risk; weights sum to 1.0. Diffusion

--- a/crates/synaptic-refactor/src/plan.rs
+++ b/crates/synaptic-refactor/src/plan.rs
@@ -19,7 +19,7 @@ pub struct RenameOptions {
     pub id: Option<String>,
     /// Disambiguate by file-path substring.
     pub file: Option<String>,
-    /// Minimum per-site confidence score [0,1] to land in `edits` (else `review`).
+    /// Minimum per-site confidence score \[0,1\] to land in `edits` (else `review`).
     pub min_confidence: f32,
     /// Max reverse-reachability depth for the blast radius.
     pub depth: usize,

--- a/crates/synaptic-server/src/lib.rs
+++ b/crates/synaptic-server/src/lib.rs
@@ -429,7 +429,7 @@ impl Server {
     }
 
     /// `query_graph` text render. The MCP `tools/call` path renders text and
-    /// structured output from a single [`query_filtered`] retrieval; this stays
+    /// structured output from a single `query_filtered` retrieval; this stays
     /// for the REST surface and direct callers.
     pub fn tool_query_graph(
         &self,
@@ -563,7 +563,7 @@ impl Server {
 
     /// `get_source` — the actual source lines for a symbol. Resolves the node,
     /// reads its file under the source-root jail, and returns a window starting
-    /// at the node's recorded line (`source_location` = "L<n>"): it stops at the
+    /// at the node's recorded line (`source_location` = `"L<n>"`): it stops at the
     /// symbol's end line when the node carries a span (bounded by `context_lines`),
     /// otherwise returns `context_lines` lines from the start.
     pub fn tool_get_source(&self, label: &str, context_lines: usize) -> String {
@@ -1635,7 +1635,7 @@ impl Server {
 
     /// Whether the loaded graph.json changed on disk since load (cheap, read-only).
     /// `false` when there's no path or the file vanished (serve-stale-on-error),
-    /// matching [`maybe_reload`](Server::maybe_reload)'s own decision.
+    /// matching `maybe_reload`'s own decision.
     pub fn is_stale(&self) -> bool {
         let Some(path) = &self.graph_path else {
             return false;

--- a/crates/synaptic-server/src/session.rs
+++ b/crates/synaptic-server/src/session.rs
@@ -25,7 +25,7 @@ struct Session {
     tx: broadcast::Sender<()>,
 }
 
-/// Thread-safe map of session id → [`Session`].
+/// Thread-safe map of session id → `Session`.
 #[derive(Default)]
 pub struct SessionStore {
     inner: Mutex<HashMap<String, Session>>,
@@ -52,7 +52,7 @@ impl SessionStore {
         id
     }
 
-    /// [`create_at`] using the real clock.
+    /// [`create_at`](Self::create_at) using the real clock.
     pub fn create(&self) -> String {
         self.create_at(Instant::now())
     }
@@ -82,7 +82,7 @@ impl SessionStore {
         }
     }
 
-    /// [`touch_at`] using the real clock.
+    /// [`touch_at`](Self::touch_at) using the real clock.
     pub fn touch(&self, id: &str) -> bool {
         self.touch_at(id, Instant::now())
     }

--- a/crates/synaptic-workspace/src/import_map.rs
+++ b/crates/synaptic-workspace/src/import_map.rs
@@ -3,7 +3,7 @@
 //! app's `package.json name`; the alias's target path contains the app's directory
 //! (`…/hub/dist/…`). Import-map aliases are **exact** (the import specifier equals the
 //! alias). The bounded walk and member resolution live in [`crate::alias`]; this module
-//! only turns one file's `imports` object into [`RawAlias`] entries.
+//! only turns one file's `imports` object into `RawAlias` entries.
 
 use crate::alias::{named_object, object_pairs, AliasKind, RawAlias};
 


### PR DESCRIPTION
The new docs job runs cargo doc with RUSTDOCFLAGS=-D warnings, which exposed pre-existing rustdoc issues: public docs linking to private items, bare [0,1] intervals parsed as intra-doc links, an unclosed <n> HTML tag, unresolved method links, and a redundant explicit link target.